### PR TITLE
Collection serialization

### DIFF
--- a/server/src/main/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiData.java
+++ b/server/src/main/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiData.java
@@ -22,4 +22,17 @@ interface JsonApiData {
 	boolean hasRelationshipTo(JsonApiIdentifiable related);
 
 	void setResourceCollectionURI(URI collectionURI);
+
+	/**
+	 * Get the resourceObject representation of this data object.
+	 * @return this, if the object is an instance of JsonApiResource, the first (and only) element of the collection if it is a one element resource collection.
+	 * @throws IllegalStateException if the data object is a resource collection containing zero or more than one elements.
+	 */
+	JsonApiResource asSingleResource() throws IllegalStateException;
+
+	/**
+	 * Get the resourceCollection representation of this data object.
+	 * @return this, if the object is an instance of JsonApiResourceCollection, a one element collection containing the resource object otherwise.
+	 */
+	JsonApiResourceCollection asResourceCollection();
 }

--- a/server/src/main/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiData.java
+++ b/server/src/main/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiData.java
@@ -1,0 +1,25 @@
+package org.jvalue.ods.rest.v2.jsonapi.response;
+
+import org.jvalue.ods.rest.v2.jsonapi.wrapper.JsonApiIdentifiable;
+
+import java.net.URI;
+import java.util.Collection;
+
+/**
+ * Interface for objects that match the "data" field of the JSONAPI specification (top level element)
+ * May be realized by either a single resource object (JsonApiResource) or an array of resource objects (JsonApiResourceCollection).
+ */
+interface JsonApiData {
+
+	JsonApiData restrictTo(String attribute);
+
+	JsonApiData addRelationship(String name, Collection<? extends JsonApiIdentifiable> relatedCollection, URI location);
+
+	JsonApiData addRelationship(String name, JsonApiIdentifiable related, URI location);
+
+	URI getRelationshipUri(JsonApiIdentifiable related);
+
+	boolean hasRelationshipTo(JsonApiIdentifiable related);
+
+	void setResourceCollectionURI(URI collectionURI);
+}

--- a/server/src/main/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiDocument.java
+++ b/server/src/main/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiDocument.java
@@ -1,6 +1,5 @@
 package org.jvalue.ods.rest.v2.jsonapi.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.jvalue.commons.utils.Assert;
 import org.jvalue.ods.rest.v2.jsonapi.wrapper.JsonApiIdentifiable;
@@ -9,7 +8,6 @@ import javax.ws.rs.core.UriInfo;
 import java.io.Serializable;
 import java.net.URI;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static org.jvalue.ods.utils.HttpUtils.appendTrailingSlash;
 
@@ -19,10 +17,7 @@ public class JsonApiDocument implements Serializable, JsonLinks {
 
 	private final Map<String, URI> links = new HashMap<>();
 
-	@JsonFormat(with = {
-		JsonFormat.Feature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED,
-		JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY})
-	protected List<JsonApiResource> data;
+	protected JsonApiData data;
 
 	protected List<JsonApiError> errors;
 
@@ -43,8 +38,7 @@ public class JsonApiDocument implements Serializable, JsonLinks {
 		Assert.assertTrue(included == null);
 
 		this.uriInfo = uriInfo;
-		data = new LinkedList<>();
-		data.add(new JsonApiResource(entity, uriInfo.getAbsolutePath()));
+		this.data = new JsonApiResource(entity, uriInfo.getAbsolutePath());
 	}
 
 
@@ -52,28 +46,20 @@ public class JsonApiDocument implements Serializable, JsonLinks {
 						   UriInfo uriInfo) {
 		Assert.assertTrue(errors == null);
 
-		data = new LinkedList<>();
 		this.uriInfo = uriInfo;
 		URI collectionURI = appendTrailingSlash(uriInfo.getAbsolutePath());
 
-		for (JsonApiIdentifiable entity : entityCollection) {
-			JsonApiResource resource = new JsonApiResource(entity, collectionURI.resolve(entity.getId()));
-			resource.addSelfLink();
-			data.add(resource);
-		}
+		data = new JsonApiResourceCollection(entityCollection, collectionURI);
 	}
 
 
 	public void setResourceCollectionURI(URI collectionURI) {
-		data.forEach(r -> {
-			r.getLinks().clear();
-			r.addLink(JsonLinks.SELF, appendTrailingSlash(collectionURI).resolve(r.getId()));
-		});
+		data.setResourceCollectionURI(collectionURI);
 	}
 
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
-	public List<JsonApiResource> getData() {
+	public JsonApiData getData() {
 		return data;
 	}
 
@@ -91,49 +77,27 @@ public class JsonApiDocument implements Serializable, JsonLinks {
 
 
 	private URI getRelationshipURI(JsonApiIdentifiable relationship) {
-		URI relationshipURI = null;
-
-		for (JsonApiResource dataElement : data) {
-			if (dataElement.hasRelationshipTo(relationship)) {
-				relationshipURI = dataElement.getRelationshipUri(relationship);
-			}
-		}
-
-		if (relationshipURI == null) {
-			throw new IllegalArgumentException("relationship " + relationship.getId() + " does not exist.");
-		}
-
-		return relationshipURI;
+		return data.getRelationshipUri(relationship);
 	}
 
 
 	public boolean hasRelationshipTo(JsonApiIdentifiable entity) {
-		return data.stream()
-			.anyMatch(e -> e.hasRelationshipTo(entity));
+		return data.hasRelationshipTo(entity);
 	}
 
 
 	public void restrictTo(String attribute) {
-		data = data
-			.stream()
-			.map(r -> r.restrictTo(attribute))
-			.collect(Collectors.toList());
+		data.restrictTo(attribute);
 	}
 
 
 	public void addRelationship(String name, JsonApiIdentifiable entity, URI location) {
-		data = data
-			.stream()
-			.map(r -> r.addRelationship(name, entity, location))
-			.collect(Collectors.toList());
+		data.addRelationship(name, entity, location);
 	}
 
 
 	public void addRelationship(String name, Collection<? extends JsonApiIdentifiable> entity, URI location) {
-		data = data
-			.stream()
-			.map(r -> r.addRelationship(name, entity, location))
-			.collect(Collectors.toList());
+		data.addRelationship(name, entity, location);
 	}
 
 

--- a/server/src/main/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiDocument.java
+++ b/server/src/main/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiDocument.java
@@ -87,7 +87,7 @@ public class JsonApiDocument implements Serializable, JsonLinks {
 
 
 	public void restrictTo(String attribute) {
-		data.restrictTo(attribute);
+		data = data.restrictTo(attribute);
 	}
 
 

--- a/server/src/main/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiDocument.java
+++ b/server/src/main/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiDocument.java
@@ -2,6 +2,7 @@ package org.jvalue.ods.rest.v2.jsonapi.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.jvalue.commons.utils.Assert;
 import org.jvalue.ods.rest.v2.jsonapi.wrapper.JsonApiIdentifiable;
 
 import javax.ws.rs.core.UriInfo;
@@ -21,27 +22,37 @@ public class JsonApiDocument implements Serializable, JsonLinks {
 	@JsonFormat(with = {
 		JsonFormat.Feature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED,
 		JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY})
-	protected List<JsonApiResource> data = new LinkedList<>();
+	protected List<JsonApiResource> data;
 
-	protected List<JsonApiError> errors = new LinkedList<>();
+	protected List<JsonApiError> errors;
 
-	private final List<JsonApiResource> included = new LinkedList<>();
+	private List<JsonApiResource> included;
 
 
 	public JsonApiDocument(JsonApiError error) {
+		Assert.assertTrue(data == null);
+
+		errors = new LinkedList<>();
 		errors.add(error);
 	}
 
 
 	public JsonApiDocument(JsonApiIdentifiable entity,
 						   UriInfo uriInfo) {
+		Assert.assertTrue(errors == null);
+		Assert.assertTrue(included == null);
+
 		this.uriInfo = uriInfo;
+		data = new LinkedList<>();
 		data.add(new JsonApiResource(entity, uriInfo.getAbsolutePath()));
 	}
 
 
 	public JsonApiDocument(Collection<? extends JsonApiIdentifiable> entityCollection,
 						   UriInfo uriInfo) {
+		Assert.assertTrue(errors == null);
+
+		data = new LinkedList<>();
 		this.uriInfo = uriInfo;
 		URI collectionURI = appendTrailingSlash(uriInfo.getAbsolutePath());
 
@@ -61,19 +72,19 @@ public class JsonApiDocument implements Serializable, JsonLinks {
 	}
 
 
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public List<JsonApiResource> getData() {
 		return data;
 	}
 
 
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public List<JsonApiError> getErrors() {
 		return errors;
 	}
 
 
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public List<JsonApiResource> getIncluded() {
 		return included;
 	}

--- a/server/src/main/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiDocument.java
+++ b/server/src/main/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiDocument.java
@@ -26,6 +26,7 @@ public class JsonApiDocument implements Serializable, JsonLinks {
 
 	public JsonApiDocument(JsonApiError error) {
 		Assert.assertTrue(data == null);
+		Assert.assertTrue(included == null);
 
 		errors = new LinkedList<>();
 		errors.add(error);
@@ -35,7 +36,6 @@ public class JsonApiDocument implements Serializable, JsonLinks {
 	public JsonApiDocument(JsonApiIdentifiable entity,
 						   UriInfo uriInfo) {
 		Assert.assertTrue(errors == null);
-		Assert.assertTrue(included == null);
 
 		this.uriInfo = uriInfo;
 		this.data = new JsonApiResource(entity, uriInfo.getAbsolutePath());

--- a/server/src/main/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiDocument.java
+++ b/server/src/main/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiDocument.java
@@ -70,7 +70,7 @@ public class JsonApiDocument implements Serializable, JsonLinks {
 	}
 
 
-	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	public List<JsonApiResource> getIncluded() {
 		return included;
 	}
@@ -102,6 +102,9 @@ public class JsonApiDocument implements Serializable, JsonLinks {
 
 
 	public void addIncluded(JsonApiIdentifiable entity) {
+		if(included == null) {
+			included = new LinkedList<>();
+		}
 		URI location = getRelationshipURI(entity);
 		JsonApiResource includedResource = new JsonApiResource(entity, location);
 		includedResource.addSelfLink();

--- a/server/src/main/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiResource.java
+++ b/server/src/main/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiResource.java
@@ -13,7 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-public class JsonApiResource extends JsonApiResourceIdentifier implements JsonLinks {
+public class JsonApiResource extends JsonApiResourceIdentifier implements JsonLinks, JsonApiData{
 
 	private final URI uri;
 	private final JsonApiIdentifiable entity;
@@ -58,13 +58,20 @@ public class JsonApiResource extends JsonApiResourceIdentifier implements JsonLi
 	}
 
 
-	protected boolean hasRelationshipTo(JsonApiIdentifiable related) {
+	@Override
+	public boolean hasRelationshipTo(JsonApiIdentifiable related) {
 		return relationships.entrySet().stream()
 			.anyMatch(r -> r.getValue().containsEntity(related));
 	}
 
+	@Override
+	public void setResourceCollectionURI(URI collectionURI) {
+		throw new IllegalStateException("Method may only be applied to resourceCollections");
+	}
 
-	protected URI getRelationshipUri(JsonApiIdentifiable related) {
+
+	@Override
+	public URI getRelationshipUri(JsonApiIdentifiable related) {
 		URI relationshipURI = null;
 
 		for (Map.Entry<String, JsonApiRelationship> entry : relationships.entrySet()) {
@@ -83,19 +90,22 @@ public class JsonApiResource extends JsonApiResourceIdentifier implements JsonLi
 	}
 
 
-	protected JsonApiResource addRelationship(String name, JsonApiIdentifiable related, URI location) {
+	@Override
+	public JsonApiResource addRelationship(String name, JsonApiIdentifiable related, URI location) {
 		relationships.put(name, new JsonApiRelationship(related, location));
 		return this;
 	}
 
 
-	protected JsonApiResource addRelationship(String name, Collection<? extends JsonApiIdentifiable> relatedCollection, URI location) {
+	@Override
+	public JsonApiResource addRelationship(String name, Collection<? extends JsonApiIdentifiable> relatedCollection, URI location) {
 		relationships.put(name, new JsonApiRelationship(relatedCollection, location));
 		return this;
 	}
 
 
-	protected JsonApiResource restrictTo(String attribute) {
+	@Override
+	public JsonApiResource restrictTo(String attribute) {
 		return new JsonApiResource(entity, uri) {
 			@Override
 			public Object getEntity() {

--- a/server/src/main/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiResource.java
+++ b/server/src/main/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiResource.java
@@ -8,12 +8,9 @@ import org.jvalue.ods.rest.v2.jsonapi.wrapper.JsonApiIdentifiable;
 import org.jvalue.ods.utils.JsonUtils;
 
 import java.net.URI;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
-public class JsonApiResource extends JsonApiResourceIdentifier implements JsonLinks, JsonApiData{
+public class JsonApiResource extends JsonApiResourceIdentifier implements JsonLinks, JsonApiData {
 
 	private final URI uri;
 	private final JsonApiIdentifiable entity;
@@ -67,6 +64,16 @@ public class JsonApiResource extends JsonApiResourceIdentifier implements JsonLi
 	@Override
 	public void setResourceCollectionURI(URI collectionURI) {
 		throw new IllegalStateException("Method may only be applied to resourceCollections");
+	}
+
+	@Override
+	public JsonApiResource asSingleResource() {
+		return this;
+	}
+
+	@Override
+	public JsonApiResourceCollection asResourceCollection() {
+		return new JsonApiResourceCollection(this);
 	}
 
 

--- a/server/src/main/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiResourceCollection.java
+++ b/server/src/main/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiResourceCollection.java
@@ -18,6 +18,12 @@ public class JsonApiResourceCollection implements JsonApiData {
 
 	private final List<JsonApiResource> resources = new LinkedList<>();
 
+
+	protected JsonApiResourceCollection(JsonApiResource resource) {
+		resources.add(resource);
+	}
+
+
 	public JsonApiResourceCollection(Collection<? extends JsonApiIdentifiable> entities, URI collectionUri) {
 		entities.forEach(
 			e -> resources.add(
@@ -26,10 +32,12 @@ public class JsonApiResourceCollection implements JsonApiData {
 
 	}
 
+
 	@JsonValue
 	public List<JsonApiResource> getResources() {
 		return resources;
 	}
+
 
 	@Override
 	public JsonApiData restrictTo(String attribute) {
@@ -40,6 +48,7 @@ public class JsonApiResourceCollection implements JsonApiData {
 		return this;
 	}
 
+
 	@Override
 	public JsonApiData addRelationship(String name, Collection<? extends JsonApiIdentifiable> relatedCollection, URI location) {
 		resources.forEach(
@@ -49,6 +58,7 @@ public class JsonApiResourceCollection implements JsonApiData {
 		return this;
 	}
 
+
 	@Override
 	public JsonApiData addRelationship(String name, JsonApiIdentifiable related, URI location) {
 		resources.forEach(
@@ -57,6 +67,7 @@ public class JsonApiResourceCollection implements JsonApiData {
 
 		return this;
 	}
+
 
 	@Override
 	public URI getRelationshipUri(JsonApiIdentifiable related) {
@@ -69,6 +80,7 @@ public class JsonApiResourceCollection implements JsonApiData {
 			.getRelationshipUri(related);
 	}
 
+
 	@Override
 	public boolean hasRelationshipTo(JsonApiIdentifiable related) {
 		return resources
@@ -76,11 +88,34 @@ public class JsonApiResourceCollection implements JsonApiData {
 				.anyMatch(r -> r.hasRelationshipTo(related));
 	}
 
+
 	@Override
 	public void setResourceCollectionURI(URI collectionURI) {
 		resources.forEach(r -> {
 				r.getLinks().clear();
 				r.addLink(JsonLinks.SELF, appendTrailingSlash(collectionURI).resolve(r.getId()));
 			});
+	}
+
+
+	public List<JsonApiResource> getEntity() {
+		return resources;
+	}
+
+
+	@Override
+	public JsonApiResource asSingleResource() {
+		if(resources.size() == 1) {
+			return resources.get(0);
+		}
+		else {
+			throw new IllegalStateException("Only collections with exactly one entry can be conversed to resource objects.");
+		}
+	}
+
+
+	@Override
+	public JsonApiResourceCollection asResourceCollection() {
+		return this;
 	}
 }

--- a/server/src/main/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiResourceCollection.java
+++ b/server/src/main/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiResourceCollection.java
@@ -1,0 +1,86 @@
+package org.jvalue.ods.rest.v2.jsonapi.response;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.jvalue.ods.rest.v2.jsonapi.wrapper.JsonApiIdentifiable;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.jvalue.ods.utils.HttpUtils.appendTrailingSlash;
+
+/**
+ * Class representation of resource collections.
+ * @JsonValue annotation on getResources() method marks resource array as serialization root.
+ */
+public class JsonApiResourceCollection implements JsonApiData {
+
+	private final List<JsonApiResource> resources = new LinkedList<>();
+
+	public JsonApiResourceCollection(Collection<? extends JsonApiIdentifiable> entities, URI collectionUri) {
+		entities.forEach(
+			e -> resources.add(
+				new JsonApiResource(e, collectionUri.resolve(e.getId()))));
+		this.resources.forEach(JsonApiResource::addSelfLink);
+
+	}
+
+	@JsonValue
+	public List<JsonApiResource> getResources() {
+		return resources;
+	}
+
+	@Override
+	public JsonApiData restrictTo(String attribute) {
+		resources.forEach(
+			r -> r.restrictTo(attribute)
+		);
+
+		return this;
+	}
+
+	@Override
+	public JsonApiData addRelationship(String name, Collection<? extends JsonApiIdentifiable> relatedCollection, URI location) {
+		resources.forEach(
+			r -> r.addRelationship(name, relatedCollection, location)
+		);
+
+		return this;
+	}
+
+	@Override
+	public JsonApiData addRelationship(String name, JsonApiIdentifiable related, URI location) {
+		resources.forEach(
+			r -> r.addRelationship(name, related, location)
+		);
+
+		return this;
+	}
+
+	@Override
+	public URI getRelationshipUri(JsonApiIdentifiable related) {
+
+		return resources
+			.stream()
+			.filter(r -> r.hasRelationshipTo(related))
+			.findAny()
+			.orElseThrow(() -> new IllegalArgumentException("relationship " + related.getId() + " does not exist."))
+			.getRelationshipUri(related);
+	}
+
+	@Override
+	public boolean hasRelationshipTo(JsonApiIdentifiable related) {
+		return resources
+				.stream()
+				.anyMatch(r -> r.hasRelationshipTo(related));
+	}
+
+	@Override
+	public void setResourceCollectionURI(URI collectionURI) {
+		resources.forEach(r -> {
+				r.getLinks().clear();
+				r.addLink(JsonLinks.SELF, appendTrailingSlash(collectionURI).resolve(r.getId()));
+			});
+	}
+}

--- a/server/src/test/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiResponseTest.java
+++ b/server/src/test/java/org/jvalue/ods/rest/v2/jsonapi/response/JsonApiResponseTest.java
@@ -105,7 +105,6 @@ public class JsonApiResponseTest {
 		//Verify
 		assertIsValidJsonApiDataResponse(result);
 		JsonNode resultJson = extractJsonEntity(result).get("data");
-		System.out.println(resultJson);
 		Assert.assertEquals(3, resultJson.size());
 		Assert.assertTrue(resultJson.has("attributes"));
 		Assert.assertEquals(1, resultJson.get("attributes").size());


### PR DESCRIPTION
Adjust serialization of collections: 
- empty collections are now serialized as json api document containing an empty json array
- one element collections are now serialized as array instead of single object